### PR TITLE
Revert "Bump rake from 10.4.2 to 13.0.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     rack (1.6.12)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rake (13.0.1)
+    rake (10.4.2)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)


### PR DESCRIPTION
Reverts bullhorn/rest-api-docs#43