### PR TITLE
Revert "Bump ffi from 1.9.10 to 1.12.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     execjs (2.6.0)
     fastimage (1.8.1)
       addressable (~> 2.3, >= 2.3.5)
-    ffi (1.12.2)
+    ffi (1.9.10)
     haml (4.0.7)
       tilt
     hamster (2.0.0)
@@ -39,7 +39,6 @@ GEM
     i18n (0.7.0)
     json (1.8.5)
     kramdown (1.9.0)
-    libv8 (3.16.14.19)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -104,14 +103,10 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
-    ref (2.0.0)
     rouge (1.10.1)
     sass (3.4.21)
     sprockets (3.4.1)
       rack (> 1, < 3)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -134,7 +129,6 @@ DEPENDENCIES
   middleman-syntax (~> 2.1.0)
   redcarpet (~> 3.3.2)
   rouge (~> 1.10.1)
-  therubyracer
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
Reverts bullhorn/rest-api-docs#46