### PR TITLE
Update clientcorporation entity owners

### DIFF
--- a/source/includes/_entity.md
+++ b/source/includes/_entity.md
@@ -167,6 +167,13 @@ You can add to-many associations to an entity with a PUT request in which you sp
 
 `{corpToken}/entity/{entityType}/{entity-id}/{to-many-association-name}/{entity-id},*}`
 
+**Note:** You cannot update `owners` to-many association on the `ClientCorporation` entity if [Company Ownership of Records](https://help.bullhorn.com/bhatsTopics/s/article/ATS-Company-Ownership-of-Records) is **NOT** enabled. 
+TBD: can you update it with PUT to
+``` shell
+`{corpToken}/entity/ClientCorporation/{entity-id}/owners/{owner-id},*}`
+```
+when the feature is enabled?
+
 Parameter | Required | Description
 ------ | -------- | -----
 BhRestToken | no | Token that represents a session established by the login process. Must be sent with all subsequent requests to the API. The session key can be provided in the BhRestToken query string, a cookie, or an HTTP header.

--- a/source/includes/entityref/_clientcorporation.md
+++ b/source/includes/entityref/_clientcorporation.md
@@ -44,7 +44,7 @@ The ClientCorporation entity supports the massUpdate operations.
 | notes | String (2147483647) | Free text field for entering any comments or notes about the company. | | |
 | numEmployees | Integer | Total number of people employed by the company. | X | |
 | numOffices | Integer | Total number of offices for the ClientCorporation. | X | |
-| owners | To-many association | Owners of the ClientContacts for this ClientCorporation. | | |
+| owners | To-many association | Owners of the ClientContacts for this ClientCorporation. **Read-only if the user's company [Company Ownership](https://help.bullhorn.com/bhatsTopics/s/article/ATS-Company-Ownership-of-Records) feature is NOT enabled; in this case, owners are inferred from the `owner` of ClientContact associated with this corporation; if the `Company Ownership` feature is enabled, <TBD: is it writeable then?>**.| | x |
 | ownerShip | String (30) | Status of the ClientCorporation's current ownership (for example, Public, Private). | | |
 | parentClientCorporation | To-one association | ClientCorporation that is a parent of this one. | | |
 | phone | String (20) | Main phone number for the ClientCorporation. | | |


### PR DESCRIPTION
Update information on the docs about the different behaviour of the to-many association of `ClientCorporation.owners`. 

Definitely if the [ATS: Company Ownership of Records](https://help.bullhorn.com/bhatsTopics/s/article/ATS-Company-Ownership-of-Records) is NOT enabled, the field is read-only (it can be changed by finding default-created (and archived) Contact and updating its owner, though).

The changes still need to update information on what would happen if the `Company Ownership of Records` is enabled. Can't find information about it. Please, help.