### PR TITLE
BH-90897 Modify the API documentation to accurately display the character limit for candidate.occupation and clientcontact.occupation 

### DIFF
--- a/source/includes/entityref/_candidate.md
+++ b/source/includes/entityref/_candidate.md
@@ -4,141 +4,141 @@ Represents a person seeking a job.
 
 The Candidate entity supports the massUpdate operations. It does not support String values for Timestamps.
 
-| **Candidate field** | **Type** | **Description** | **Not null** | **Read-only** |
-| --- | --- | --- | --- | --- |
-| id | Integer | Unique identifier for this entity. | X | X |
-| address | Address | Candidate address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/Candidate?fields=address(countryID) | | |
-| blacklistClientCorporations | To-many association | Set of ClientCorporations blacklisted for this Candidate. | | |
-| businessSectors | To-many association | Ids of BusinessSectors with which Candidate is associated. | | |
-| candidateSource | To-one association | Source of the Candidate. |   X | |
-| category | To-one association | Candidate's primary Category. The default value is the Other Area(s) category for the user’s private label or the first Category.<br>**Note:** This property refers to the original category assigned to the Candidate. To retrieve or update categories for the Candidate, you should use the categories associations (see below). | X | |
-| categories | To-many association | Categories assigned to Candidate. | | |
-| certifications | String (2147483647) | Candidate's certifications. | | |
-| clientRating | Integer | Score from BH Automation Client Rating Tool. | | |
-| comments | String (2147483647) | Free-text comments on Candidate. | X | |
-| companyName | String (100) | Name of company where the Candidate currently works. | | |
-| companyURL | String (100) | Candidate's personal URL. | | |
-| customDate1 to 13 | Timestamp | Configurable date fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customEncryptedText1 to 10 | String (100) | Configurable encrypted text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customFloat1 to 23 | Double | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customInt1 to 23 | Integer | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customObject1s to 35s | CustomObject | Fields to which custom objects can be assigned. For more information about custom objects, see the Bullhorn Resource Center and the following article on using the REST API with custom objects:<br>[http://bullhorn.github.io/Custom-Objects](http://bullhorn.github.io/Custom-Objects) | | |
-| customText1 to 60 | String (100) | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customTextBlock1 to 10 | String (2147483647) | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| dateAdded | Timestamp | Date on which this record was created in the Bullhorn system. | X | X |
-| dateAvailable | Timestamp | Date on which Candidate will be available to begin work. | | |
-| dateAvailableEnd | Timestamp | Date on which Candidate's availability will end, if applicable. | | |
-| dateI9Expiration | Timestamp | Date on which the Candidate's I9 form will expire. | | |
-| dateLastComment | Timestamp | Date of the most recent Note referencing Candidate. | | X |
-| dateLastModified | Timestamp | Date the Candidate was last modified. | X | X |
-| dateNextCall | Timestamp | Date when the Candidate should next be called. | | |
-| dateOfBirth | Timestamp | Candidate's date of birth. | | |
-| dayRate | BigDecimal | Candidate's desired per-day pay rate. | | |
-| dayRateLow | BigDecimal | Lowest per-day rate the Candidate will accept. | | |
-| degreeList | String (2147483647) | List of Candidate's educational degrees. Field on the edit screen, not the field in People Template. | | |
-| description | String (2147483647) | Text field, usually used to contain the Candidate's resume. | | |
-| desiredLocations | String (2147483647) | Locations where Candidate would like to work. | | |
-| disability | String (1) | Indicates whether Candidate has a disability. Allowable values can be configured using field maps. Default values are U (Unknown), Y (Yes), and N (No). | | |
-| educationDegree | String (2147483647) | Candidate's highest level of education. | | |
-| email | String (100) | Candidate's email address. | | |
-| email2 | String (100) | Additional email address. | | |
-| email3 | String (100) | Additional email address. | | |
-| employeeType | String (30) | Candidate's employee type: for example 1099 or W2. | X | |
-| employmentPreference | String (200) | Indicates type of employment the Candidate would prefer: for example, permanent, part-time, and so forth. |
-| ethnicity | String (50) | Candidate's ethnicity. | | |
-| experience | Integer | Number of years of experience that the Candidate has. | | |
-| externalID | String (50) | Used for records migrated in from other systems; often used for the Candidate's external/backoffice Id. |
-| fax | String (20) | Candidate's fax number. | | |
-| fax2 | String (20) | Additional fax number. | | |
-| fax3 | String (20) | Additional fax number. | | |
-| federalAdditionalWitholdingsAmount | BigDecimal | Number of federal withholdings the Candidate has selected on his or her W-2 tax form. | | |
-| federalExemptions | Integer | Number of federal exemptions the Candidate has indicated on his or her W-2 tax form. | | |
-| federalExtraWithholdingAmount | BigDecimal | Enter any additional tax you want withheld each pay period. | | |
-| federalFilingStatus | String (1) | Candidate's federal tax filing status. | | |
-| firstName | String (50) | Candidate's first name. | X | |
-| gender | String (1) | Candidate's gender. Options are U (unknown), M (male), F (female) | | |
-| hourlyRate | BigDecimal | Candidate's desired hourly pay rate. | | |
-| hourlyRateLow | BigDecimal | Lowest hourly pay rate the Candidate will accept. | | |
-| i9OnFile | Integer | Indicates whether Candidate's I-9 form has already been filled out and is on file. | | |
-| interviews | To-many association | Interviews for Candidate. This field is populated when you create Appointments where Appointment.candidate is this Candidate and Appointment.type is “Interview”. | X | |
-| isAnonymized | Boolean | Indicates whether this record is marked as anonymized in the Bullhorn system. | | |
-| isDeleted | Boolean | Indicates whether this record is marked as deleted in the Bullhorn system. | X | |
-| isEditable | Boolean | Indicates whether Candidate can edit his or her profile information; applicable to Candidate/Client login. | X |
-| isExempt | Boolean | To claim exemption from withholding, set this to Yes. | | |
-| lastName | String (50) | Candidate's last name. | X | |
-| leads | To-many association | Leads associated with this Candidate. | | |
-| linkedPerson | To-one association | If person represented by Candidate is also a ClientContact, this field includes the following ClientContact fields<br>: id, _subtype | | |
-| localAddtionalWitholdingsAmount | BigDecimal | Number of local withholdings the Candidate has selected on his or her W-2 tax form. | | |
-| localExemptions | Integer | Number of local exemptions Candidate has indicated on his or her W-2 tax form. | | |
-| localFilingStatus | String (1) | Candidate's local tax filing status. | | |
-| localTaxCode | String (40) | Candidate's local tax code (if local taxes apply); not required. | | |
-| maritalStatus | String | Indicates the current marital status of the candidate. | | |
-| massMailOptOut | Boolean | Indicates whether Candidate has chosen not to be included in mass emails through the Bullhorn system. | | |
-| middleName | String (50) | Candidate's middle name. | | |
-| mobile | String (20) | Candidate's mobile (cell) telephone number. | | |
-| name | String | Candidate's full name. If setting firstname or lastname, you must also set this field; it does not populate automatically. | X | |
-| namePrefix | String (5) | Candidate's name prefix, for example Dr., Ms., Mr., and so forth. | | |
-| nameSuffix | String (5) | Candidate's name suffix, for example Jr. | | |
-| nickName | String (50) | Candidate's nickname. | | |
-| numCategories | Integer | Number of Category objects associated with Candidate. | | |
-| numOwners | Integer | Number of CorporateUsers that are listed as owner of Candidate. | | |
-| occupation | String (50) | Candidate's current occupation or job title. | | |
-| onboardingDocumentReceivedCount | Integer |  Number of eStaff onboarding documents that have been received by the Candidate. | | |
-| onboardingDocumentSentCount | Integer | Number of eStaff onboarding documents that have been sent and completed by the Candidate. | | |
-| onboardingPercentComplete | Integer | Percentage of eStaff onboarding documents that a Candidate has completed. | | |
+| **Candidate field** | **Type**               | **Description** | **Not null** | **Read-only** |
+| --- |------------------------| --- | --- | --- |
+| id | Integer                | Unique identifier for this entity. | X | X |
+| address | Address                | Candidate address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/Candidate?fields=address(countryID) | | |
+| blacklistClientCorporations | To-many association    | Set of ClientCorporations blacklisted for this Candidate. | | |
+| businessSectors | To-many association    | Ids of BusinessSectors with which Candidate is associated. | | |
+| candidateSource | To-one association     | Source of the Candidate. |   X | |
+| category | To-one association     | Candidate's primary Category. The default value is the Other Area(s) category for the user’s private label or the first Category.<br>**Note:** This property refers to the original category assigned to the Candidate. To retrieve or update categories for the Candidate, you should use the categories associations (see below). | X | |
+| categories | To-many association    | Categories assigned to Candidate. | | |
+| certifications | String (2147483647)    | Candidate's certifications. | | |
+| clientRating | Integer                | Score from BH Automation Client Rating Tool. | | |
+| comments | String (2147483647)    | Free-text comments on Candidate. | X | |
+| companyName | String (100)           | Name of company where the Candidate currently works. | | |
+| companyURL | String (100)           | Candidate's personal URL. | | |
+| customDate1 to 13 | Timestamp              | Configurable date fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customEncryptedText1 to 10 | String (100)           | Configurable encrypted text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customFloat1 to 23 | Double                 | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customInt1 to 23 | Integer                | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customObject1s to 35s | CustomObject           | Fields to which custom objects can be assigned. For more information about custom objects, see the Bullhorn Resource Center and the following article on using the REST API with custom objects:<br>[http://bullhorn.github.io/Custom-Objects](http://bullhorn.github.io/Custom-Objects) | | |
+| customText1 to 60 | String (100)           | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customTextBlock1 to 10 | String (2147483647)    | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| dateAdded | Timestamp              | Date on which this record was created in the Bullhorn system. | X | X |
+| dateAvailable | Timestamp              | Date on which Candidate will be available to begin work. | | |
+| dateAvailableEnd | Timestamp              | Date on which Candidate's availability will end, if applicable. | | |
+| dateI9Expiration | Timestamp              | Date on which the Candidate's I9 form will expire. | | |
+| dateLastComment | Timestamp              | Date of the most recent Note referencing Candidate. | | X |
+| dateLastModified | Timestamp              | Date the Candidate was last modified. | X | X |
+| dateNextCall | Timestamp              | Date when the Candidate should next be called. | | |
+| dateOfBirth | Timestamp              | Candidate's date of birth. | | |
+| dayRate | BigDecimal             | Candidate's desired per-day pay rate. | | |
+| dayRateLow | BigDecimal             | Lowest per-day rate the Candidate will accept. | | |
+| degreeList | String (2147483647)    | List of Candidate's educational degrees. Field on the edit screen, not the field in People Template. | | |
+| description | String (2147483647)    | Text field, usually used to contain the Candidate's resume. | | |
+| desiredLocations | String (2147483647)    | Locations where Candidate would like to work. | | |
+| disability | String (1)             | Indicates whether Candidate has a disability. Allowable values can be configured using field maps. Default values are U (Unknown), Y (Yes), and N (No). | | |
+| educationDegree | String (2147483647)    | Candidate's highest level of education. | | |
+| email | String (100)           | Candidate's email address. | | |
+| email2 | String (100)           | Additional email address. | | |
+| email3 | String (100)           | Additional email address. | | |
+| employeeType | String (30)            | Candidate's employee type: for example 1099 or W2. | X | |
+| employmentPreference | String (200)           | Indicates type of employment the Candidate would prefer: for example, permanent, part-time, and so forth. |
+| ethnicity | String (50)            | Candidate's ethnicity. | | |
+| experience | Integer                | Number of years of experience that the Candidate has. | | |
+| externalID | String (50)            | Used for records migrated in from other systems; often used for the Candidate's external/backoffice Id. |
+| fax | String (20)            | Candidate's fax number. | | |
+| fax2 | String (20)            | Additional fax number. | | |
+| fax3 | String (20)            | Additional fax number. | | |
+| federalAdditionalWitholdingsAmount | BigDecimal             | Number of federal withholdings the Candidate has selected on his or her W-2 tax form. | | |
+| federalExemptions | Integer                | Number of federal exemptions the Candidate has indicated on his or her W-2 tax form. | | |
+| federalExtraWithholdingAmount | BigDecimal             | Enter any additional tax you want withheld each pay period. | | |
+| federalFilingStatus | String (1)             | Candidate's federal tax filing status. | | |
+| firstName | String (50)            | Candidate's first name. | X | |
+| gender | String (1)             | Candidate's gender. Options are U (unknown), M (male), F (female) | | |
+| hourlyRate | BigDecimal             | Candidate's desired hourly pay rate. | | |
+| hourlyRateLow | BigDecimal             | Lowest hourly pay rate the Candidate will accept. | | |
+| i9OnFile | Integer                | Indicates whether Candidate's I-9 form has already been filled out and is on file. | | |
+| interviews | To-many association    | Interviews for Candidate. This field is populated when you create Appointments where Appointment.candidate is this Candidate and Appointment.type is “Interview”. | X | |
+| isAnonymized | Boolean                | Indicates whether this record is marked as anonymized in the Bullhorn system. | | |
+| isDeleted | Boolean                | Indicates whether this record is marked as deleted in the Bullhorn system. | X | |
+| isEditable | Boolean                | Indicates whether Candidate can edit his or her profile information; applicable to Candidate/Client login. | X |
+| isExempt | Boolean                | To claim exemption from withholding, set this to Yes. | | |
+| lastName | String (50)            | Candidate's last name. | X | |
+| leads | To-many association    | Leads associated with this Candidate. | | |
+| linkedPerson | To-one association     | If person represented by Candidate is also a ClientContact, this field includes the following ClientContact fields<br>: id, _subtype | | |
+| localAddtionalWitholdingsAmount | BigDecimal             | Number of local withholdings the Candidate has selected on his or her W-2 tax form. | | |
+| localExemptions | Integer                | Number of local exemptions Candidate has indicated on his or her W-2 tax form. | | |
+| localFilingStatus | String (1)             | Candidate's local tax filing status. | | |
+| localTaxCode | String (40)            | Candidate's local tax code (if local taxes apply); not required. | | |
+| maritalStatus | String                 | Indicates the current marital status of the candidate. | | |
+| massMailOptOut | Boolean                | Indicates whether Candidate has chosen not to be included in mass emails through the Bullhorn system. | | |
+| middleName | String (50)            | Candidate's middle name. | | |
+| mobile | String (20)            | Candidate's mobile (cell) telephone number. | | |
+| name | String                 | Candidate's full name. If setting firstname or lastname, you must also set this field; it does not populate automatically. | X | |
+| namePrefix | String (5)             | Candidate's name prefix, for example Dr., Ms., Mr., and so forth. | | |
+| nameSuffix | String (5)             | Candidate's name suffix, for example Jr. | | |
+| nickName | String (50)            | Candidate's nickname. | | |
+| numCategories | Integer                | Number of Category objects associated with Candidate. | | |
+| numOwners | Integer                | Number of CorporateUsers that are listed as owner of Candidate. | | |
+| occupation | String (100)           | Candidate's current occupation or job title. | | |
+| onboardingDocumentReceivedCount | Integer                |  Number of eStaff onboarding documents that have been received by the Candidate. | | |
+| onboardingDocumentSentCount | Integer                | Number of eStaff onboarding documents that have been sent and completed by the Candidate. | | |
+| onboardingPercentComplete | Integer                | Percentage of eStaff onboarding documents that a Candidate has completed. | | |
 | onboardingReceivedSent | OnboardingReceivedSent | Readonly composite field that contains:<ul><li>onboardingDocumentReceivedCount</li><li>onboardingDocumentSentCount</li></ul></ul> Use this to only view these fields.<br>To update, update the fields directly. | | |
-| onboardingStatus | String | Candidate's eStaff onboarding status. | | |
-| otherDeductionsAmount | BigDecimal |  If there are other deductions to be claimed (other than standard). | | |
-| otherIncomeAmount | BigDecimal | If you want tax withheld for other income that is expected. | | |
-| owner | To-one association | CorporateUser who is the primary owner of Candidate. The default value is user who creates the Candidate. | X | |
-| pager | String (20) | Candidate's pager number. | | |
-| paperWorkOnFile | String | Configurable field that tracks whether the Candidate's tax paperwork has been received. | | |
-| password | String | Candidate’s password. The default value is a randomly generated string. | X | |
-| payrollClientStartDate  | Timestamp | Indicates Date on which the employee was first on payroll at the staffing company. Used for payroll integrations. | | |
-| payrollStatus | String | Indicates whether the Candidate is currently active on payroll or not. Used for payroll integrations. | | |
-| phone | String (20) | Candidate's home telephone number. | | |
-| phone2 | String (20) | Candidate's telephone number at work. | | |
-| phone3 | String (20) | Alternate telephone number. | | |
-| placements | To-many association | Placements for Candidate. This field is populated when you create Placements where Placement.candidate is this Candidate. | X | |
-| preferredContact | String (15) | Candidate's preferred method of contact (for example, phone, email, and so forth.) | X | |
-| primarySkills | To-many association | Skills that are listed as primary Skills for Candidate. | | |
-| recentClientList | String (2147483647) | List of ClientCorporations for which Candidate has worked. | | |
-| referredBy | String (50) | Name of person who referred Candidate. | | |
-| referredByPerson | To-one association | Person who referred Candidate, if applicable. | | |
-| salary | BigDecimal | Candidate's desired yearly salary. | | |
-| salaryLow | BigDecimal | Lowest yearly salary the Candidate will accept. | | |
-| secondaryAddress | Address | Candidate's work address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/Candidate?fields=address(countryID) | | |
-| secondaryOwners | To-many association | CorporateUsers who are additional owners of Candidate. | | |
-| secondarySkills | Skill | Skills that are listed as secondary skills for Candidate. | | |
-| sendouts | To-many association | Sendouts for Candidate. This field is populated when you create Sendouts where the Sendout.candidate is this Candidate. | | |
-| skillSet | String (2147483647) | Text description of Candidate's skills. | | |
-| smsOptIn | Boolean | Indicates whether Candidate has granted permission to be sent messages via SMS. Can only set on create calls; updates are not allowed. | | |
-| source | String (200) | Candidate source: for example, Advertisement, Client Referral, LinkedIn, Monster.com, and so forth. Allowable values can be configured using field maps. | | |
-| specialties | To-many association | Candidate’s specialty skills. This field is populated when you associate a Specialty with this Candidate in a to-many association operation. | | |
-| ssn | String (18) | Candidate's Social Security Number. Check field map for proper format. | | |
-| stateAddtionalWitholdingsAmount | BigDecimal | Number of state withholdings Candidate has selected on his or her W-2 tax form. | | |
-| stateExemptions | Integer | Number of state exemptions Candidate has indicated on W-2 tax form. | | |
-| stateFilingStatus | String (1) | Candidate's state tax filing status. | | |
-| status | String (100) | Candidate status with company: for example, New Lead, Active, Offer Pending, Placed, and so forth. Allowable values can be configured using field maps. | X | |
-| submissions | To-many association | JobSubmissions for Candidate. This field is populated when you create JobSubmissions where JobSubmission.candidate is this Candidate. | X | |
-| tasks | To-many association | Tasks associated with Candidate. This field is populated when you create Tasks where Task.candidate is this Candidate. | | |
-| taxID | String (18) | Id that Candidate uses for tax purposes if not SSN. | | |
-| taxState | String (30) | State in which Candidate pays taxes. | | |
-| timeZoneOffsetEST | Integer | Indicates the number of hours by which the Candidate's time zone differs from Eastern Standard Time. For example, Pacific Standard Time is -3, three hours earlier than Eastern. | | |
-| tobaccoUser | String | Indicates the tobacco usage of the candidate. | | |
-| totalDependentClaimAmount | BigDecimal |  Total amount that are being claimed for dependents. | | |
-| travelLimit | Integer | Maximum distance Candidate is willing to travel. | | |
-| travelMethod | String (100) | Method of travel to job. | | |
-| twoJobs | Boolean | If more then one job is held at a time OR if the person is married and filing jointly and their spouse also works. | | |
-| type | String (100) | Candidate type: for example, Active, Passive, and so forth. | | |
-| userDateAdded | Timestamp | Date the record was added to the system. | X | |
-| username | String (100) | Candidate’s username for logging in to Bullhorn. The default value is _[random number] | X | |
-| veteran | String (1) | Indicates whether Candidate is a veteran: Y for yes, N for no, or U for unknown. | | |
-| webResponses | To-many association | Web responses for Candidate. This field is populated when you create JobSubmissions where JobSubmission.candidate is this Candidate and JobSubmission.status is “New Lead”. | | |
-| whitelistClientCorporations | To-many association | Set of ClientCorporations whitelisted for this Candidate. | | |
-| willRelocate | Boolean | Indicates whether Candidate is willing to relocate for a position. | | |
-| workAuthorized | Boolean | Indicates whether Candidate is authorized to work in the U.S. | | |
-| workPhone | String (20) | Candidate's telephone number at work. | | | |
+| onboardingStatus | String                 | Candidate's eStaff onboarding status. | | |
+| otherDeductionsAmount | BigDecimal             |  If there are other deductions to be claimed (other than standard). | | |
+| otherIncomeAmount | BigDecimal             | If you want tax withheld for other income that is expected. | | |
+| owner | To-one association     | CorporateUser who is the primary owner of Candidate. The default value is user who creates the Candidate. | X | |
+| pager | String (20)            | Candidate's pager number. | | |
+| paperWorkOnFile | String                 | Configurable field that tracks whether the Candidate's tax paperwork has been received. | | |
+| password | String                 | Candidate’s password. The default value is a randomly generated string. | X | |
+| payrollClientStartDate  | Timestamp              | Indicates Date on which the employee was first on payroll at the staffing company. Used for payroll integrations. | | |
+| payrollStatus | String                 | Indicates whether the Candidate is currently active on payroll or not. Used for payroll integrations. | | |
+| phone | String (20)            | Candidate's home telephone number. | | |
+| phone2 | String (20)            | Candidate's telephone number at work. | | |
+| phone3 | String (20)            | Alternate telephone number. | | |
+| placements | To-many association    | Placements for Candidate. This field is populated when you create Placements where Placement.candidate is this Candidate. | X | |
+| preferredContact | String (15)            | Candidate's preferred method of contact (for example, phone, email, and so forth.) | X | |
+| primarySkills | To-many association    | Skills that are listed as primary Skills for Candidate. | | |
+| recentClientList | String (2147483647)    | List of ClientCorporations for which Candidate has worked. | | |
+| referredBy | String (50)            | Name of person who referred Candidate. | | |
+| referredByPerson | To-one association     | Person who referred Candidate, if applicable. | | |
+| salary | BigDecimal             | Candidate's desired yearly salary. | | |
+| salaryLow | BigDecimal             | Lowest yearly salary the Candidate will accept. | | |
+| secondaryAddress | Address                | Candidate's work address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/Candidate?fields=address(countryID) | | |
+| secondaryOwners | To-many association    | CorporateUsers who are additional owners of Candidate. | | |
+| secondarySkills | Skill                  | Skills that are listed as secondary skills for Candidate. | | |
+| sendouts | To-many association    | Sendouts for Candidate. This field is populated when you create Sendouts where the Sendout.candidate is this Candidate. | | |
+| skillSet | String (2147483647)    | Text description of Candidate's skills. | | |
+| smsOptIn | Boolean                | Indicates whether Candidate has granted permission to be sent messages via SMS. Can only set on create calls; updates are not allowed. | | |
+| source | String (200)           | Candidate source: for example, Advertisement, Client Referral, LinkedIn, Monster.com, and so forth. Allowable values can be configured using field maps. | | |
+| specialties | To-many association    | Candidate’s specialty skills. This field is populated when you associate a Specialty with this Candidate in a to-many association operation. | | |
+| ssn | String (18)            | Candidate's Social Security Number. Check field map for proper format. | | |
+| stateAddtionalWitholdingsAmount | BigDecimal             | Number of state withholdings Candidate has selected on his or her W-2 tax form. | | |
+| stateExemptions | Integer                | Number of state exemptions Candidate has indicated on W-2 tax form. | | |
+| stateFilingStatus | String (1)             | Candidate's state tax filing status. | | |
+| status | String (100)           | Candidate status with company: for example, New Lead, Active, Offer Pending, Placed, and so forth. Allowable values can be configured using field maps. | X | |
+| submissions | To-many association    | JobSubmissions for Candidate. This field is populated when you create JobSubmissions where JobSubmission.candidate is this Candidate. | X | |
+| tasks | To-many association    | Tasks associated with Candidate. This field is populated when you create Tasks where Task.candidate is this Candidate. | | |
+| taxID | String (18)            | Id that Candidate uses for tax purposes if not SSN. | | |
+| taxState | String (30)            | State in which Candidate pays taxes. | | |
+| timeZoneOffsetEST | Integer                | Indicates the number of hours by which the Candidate's time zone differs from Eastern Standard Time. For example, Pacific Standard Time is -3, three hours earlier than Eastern. | | |
+| tobaccoUser | String                 | Indicates the tobacco usage of the candidate. | | |
+| totalDependentClaimAmount | BigDecimal             |  Total amount that are being claimed for dependents. | | |
+| travelLimit | Integer                | Maximum distance Candidate is willing to travel. | | |
+| travelMethod | String (100)           | Method of travel to job. | | |
+| twoJobs | Boolean                | If more then one job is held at a time OR if the person is married and filing jointly and their spouse also works. | | |
+| type | String (100)           | Candidate type: for example, Active, Passive, and so forth. | | |
+| userDateAdded | Timestamp              | Date the record was added to the system. | X | |
+| username | String (100)           | Candidate’s username for logging in to Bullhorn. The default value is _[random number] | X | |
+| veteran | String (1)             | Indicates whether Candidate is a veteran: Y for yes, N for no, or U for unknown. | | |
+| webResponses | To-many association    | Web responses for Candidate. This field is populated when you create JobSubmissions where JobSubmission.candidate is this Candidate and JobSubmission.status is “New Lead”. | | |
+| whitelistClientCorporations | To-many association    | Set of ClientCorporations whitelisted for this Candidate. | | |
+| willRelocate | Boolean                | Indicates whether Candidate is willing to relocate for a position. | | |
+| workAuthorized | Boolean                | Indicates whether Candidate is authorized to work in the U.S. | | |
+| workPhone | String (20)            | Candidate's telephone number at work. | | | |
 
 ## Candidate confidential fields
 

--- a/source/includes/entityref/_candidate.md
+++ b/source/includes/entityref/_candidate.md
@@ -4,141 +4,141 @@ Represents a person seeking a job.
 
 The Candidate entity supports the massUpdate operations. It does not support String values for Timestamps.
 
-| **Candidate field** | **Type**               | **Description** | **Not null** | **Read-only** |
-| --- |------------------------| --- | --- | --- |
-| id | Integer                | Unique identifier for this entity. | X | X |
-| address | Address                | Candidate address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/Candidate?fields=address(countryID) | | |
-| blacklistClientCorporations | To-many association    | Set of ClientCorporations blacklisted for this Candidate. | | |
-| businessSectors | To-many association    | Ids of BusinessSectors with which Candidate is associated. | | |
-| candidateSource | To-one association     | Source of the Candidate. |   X | |
-| category | To-one association     | Candidate's primary Category. The default value is the Other Area(s) category for the user’s private label or the first Category.<br>**Note:** This property refers to the original category assigned to the Candidate. To retrieve or update categories for the Candidate, you should use the categories associations (see below). | X | |
-| categories | To-many association    | Categories assigned to Candidate. | | |
-| certifications | String (2147483647)    | Candidate's certifications. | | |
-| clientRating | Integer                | Score from BH Automation Client Rating Tool. | | |
-| comments | String (2147483647)    | Free-text comments on Candidate. | X | |
-| companyName | String (100)           | Name of company where the Candidate currently works. | | |
-| companyURL | String (100)           | Candidate's personal URL. | | |
-| customDate1 to 13 | Timestamp              | Configurable date fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customEncryptedText1 to 10 | String (100)           | Configurable encrypted text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customFloat1 to 23 | Double                 | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customInt1 to 23 | Integer                | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customObject1s to 35s | CustomObject           | Fields to which custom objects can be assigned. For more information about custom objects, see the Bullhorn Resource Center and the following article on using the REST API with custom objects:<br>[http://bullhorn.github.io/Custom-Objects](http://bullhorn.github.io/Custom-Objects) | | |
-| customText1 to 60 | String (100)           | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customTextBlock1 to 10 | String (2147483647)    | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| dateAdded | Timestamp              | Date on which this record was created in the Bullhorn system. | X | X |
-| dateAvailable | Timestamp              | Date on which Candidate will be available to begin work. | | |
-| dateAvailableEnd | Timestamp              | Date on which Candidate's availability will end, if applicable. | | |
-| dateI9Expiration | Timestamp              | Date on which the Candidate's I9 form will expire. | | |
-| dateLastComment | Timestamp              | Date of the most recent Note referencing Candidate. | | X |
-| dateLastModified | Timestamp              | Date the Candidate was last modified. | X | X |
-| dateNextCall | Timestamp              | Date when the Candidate should next be called. | | |
-| dateOfBirth | Timestamp              | Candidate's date of birth. | | |
-| dayRate | BigDecimal             | Candidate's desired per-day pay rate. | | |
-| dayRateLow | BigDecimal             | Lowest per-day rate the Candidate will accept. | | |
-| degreeList | String (2147483647)    | List of Candidate's educational degrees. Field on the edit screen, not the field in People Template. | | |
-| description | String (2147483647)    | Text field, usually used to contain the Candidate's resume. | | |
-| desiredLocations | String (2147483647)    | Locations where Candidate would like to work. | | |
-| disability | String (1)             | Indicates whether Candidate has a disability. Allowable values can be configured using field maps. Default values are U (Unknown), Y (Yes), and N (No). | | |
-| educationDegree | String (2147483647)    | Candidate's highest level of education. | | |
-| email | String (100)           | Candidate's email address. | | |
-| email2 | String (100)           | Additional email address. | | |
-| email3 | String (100)           | Additional email address. | | |
-| employeeType | String (30)            | Candidate's employee type: for example 1099 or W2. | X | |
-| employmentPreference | String (200)           | Indicates type of employment the Candidate would prefer: for example, permanent, part-time, and so forth. |
-| ethnicity | String (50)            | Candidate's ethnicity. | | |
-| experience | Integer                | Number of years of experience that the Candidate has. | | |
-| externalID | String (50)            | Used for records migrated in from other systems; often used for the Candidate's external/backoffice Id. |
-| fax | String (20)            | Candidate's fax number. | | |
-| fax2 | String (20)            | Additional fax number. | | |
-| fax3 | String (20)            | Additional fax number. | | |
-| federalAdditionalWitholdingsAmount | BigDecimal             | Number of federal withholdings the Candidate has selected on his or her W-2 tax form. | | |
-| federalExemptions | Integer                | Number of federal exemptions the Candidate has indicated on his or her W-2 tax form. | | |
-| federalExtraWithholdingAmount | BigDecimal             | Enter any additional tax you want withheld each pay period. | | |
-| federalFilingStatus | String (1)             | Candidate's federal tax filing status. | | |
-| firstName | String (50)            | Candidate's first name. | X | |
-| gender | String (1)             | Candidate's gender. Options are U (unknown), M (male), F (female) | | |
-| hourlyRate | BigDecimal             | Candidate's desired hourly pay rate. | | |
-| hourlyRateLow | BigDecimal             | Lowest hourly pay rate the Candidate will accept. | | |
-| i9OnFile | Integer                | Indicates whether Candidate's I-9 form has already been filled out and is on file. | | |
-| interviews | To-many association    | Interviews for Candidate. This field is populated when you create Appointments where Appointment.candidate is this Candidate and Appointment.type is “Interview”. | X | |
-| isAnonymized | Boolean                | Indicates whether this record is marked as anonymized in the Bullhorn system. | | |
-| isDeleted | Boolean                | Indicates whether this record is marked as deleted in the Bullhorn system. | X | |
-| isEditable | Boolean                | Indicates whether Candidate can edit his or her profile information; applicable to Candidate/Client login. | X |
-| isExempt | Boolean                | To claim exemption from withholding, set this to Yes. | | |
-| lastName | String (50)            | Candidate's last name. | X | |
-| leads | To-many association    | Leads associated with this Candidate. | | |
-| linkedPerson | To-one association     | If person represented by Candidate is also a ClientContact, this field includes the following ClientContact fields<br>: id, _subtype | | |
-| localAddtionalWitholdingsAmount | BigDecimal             | Number of local withholdings the Candidate has selected on his or her W-2 tax form. | | |
-| localExemptions | Integer                | Number of local exemptions Candidate has indicated on his or her W-2 tax form. | | |
-| localFilingStatus | String (1)             | Candidate's local tax filing status. | | |
-| localTaxCode | String (40)            | Candidate's local tax code (if local taxes apply); not required. | | |
-| maritalStatus | String                 | Indicates the current marital status of the candidate. | | |
-| massMailOptOut | Boolean                | Indicates whether Candidate has chosen not to be included in mass emails through the Bullhorn system. | | |
-| middleName | String (50)            | Candidate's middle name. | | |
-| mobile | String (20)            | Candidate's mobile (cell) telephone number. | | |
-| name | String                 | Candidate's full name. If setting firstname or lastname, you must also set this field; it does not populate automatically. | X | |
-| namePrefix | String (5)             | Candidate's name prefix, for example Dr., Ms., Mr., and so forth. | | |
-| nameSuffix | String (5)             | Candidate's name suffix, for example Jr. | | |
-| nickName | String (50)            | Candidate's nickname. | | |
-| numCategories | Integer                | Number of Category objects associated with Candidate. | | |
-| numOwners | Integer                | Number of CorporateUsers that are listed as owner of Candidate. | | |
-| occupation | String (100)           | Candidate's current occupation or job title. | | |
-| onboardingDocumentReceivedCount | Integer                |  Number of eStaff onboarding documents that have been received by the Candidate. | | |
-| onboardingDocumentSentCount | Integer                | Number of eStaff onboarding documents that have been sent and completed by the Candidate. | | |
-| onboardingPercentComplete | Integer                | Percentage of eStaff onboarding documents that a Candidate has completed. | | |
+| **Candidate field** | **Type** | **Description** | **Not null** | **Read-only** |
+| --- | --- | --- | --- | --- |
+| id | Integer | Unique identifier for this entity. | X | X |
+| address | Address | Candidate address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/Candidate?fields=address(countryID) | | |
+| blacklistClientCorporations | To-many association | Set of ClientCorporations blacklisted for this Candidate. | | |
+| businessSectors | To-many association | Ids of BusinessSectors with which Candidate is associated. | | |
+| candidateSource | To-one association | Source of the Candidate. |   X | |
+| category | To-one association | Candidate's primary Category. The default value is the Other Area(s) category for the user’s private label or the first Category.<br>**Note:** This property refers to the original category assigned to the Candidate. To retrieve or update categories for the Candidate, you should use the categories associations (see below). | X | |
+| categories | To-many association | Categories assigned to Candidate. | | |
+| certifications | String (2147483647) | Candidate's certifications. | | |
+| clientRating | Integer | Score from BH Automation Client Rating Tool. | | |
+| comments | String (2147483647) | Free-text comments on Candidate. | X | |
+| companyName | String (100) | Name of company where the Candidate currently works. | | |
+| companyURL | String (100) | Candidate's personal URL. | | |
+| customDate1 to 13 | Timestamp | Configurable date fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customEncryptedText1 to 10 | String (100) | Configurable encrypted text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customFloat1 to 23 | Double | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customInt1 to 23 | Integer | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customObject1s to 35s | CustomObject | Fields to which custom objects can be assigned. For more information about custom objects, see the Bullhorn Resource Center and the following article on using the REST API with custom objects:<br>[http://bullhorn.github.io/Custom-Objects](http://bullhorn.github.io/Custom-Objects) | | |
+| customText1 to 60 | String (100) | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customTextBlock1 to 10 | String (2147483647) | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| dateAdded | Timestamp | Date on which this record was created in the Bullhorn system. | X | X |
+| dateAvailable | Timestamp | Date on which Candidate will be available to begin work. | | |
+| dateAvailableEnd | Timestamp | Date on which Candidate's availability will end, if applicable. | | |
+| dateI9Expiration | Timestamp | Date on which the Candidate's I9 form will expire. | | |
+| dateLastComment | Timestamp | Date of the most recent Note referencing Candidate. | | X |
+| dateLastModified | Timestamp | Date the Candidate was last modified. | X | X |
+| dateNextCall | Timestamp | Date when the Candidate should next be called. | | |
+| dateOfBirth | Timestamp | Candidate's date of birth. | | |
+| dayRate | BigDecimal | Candidate's desired per-day pay rate. | | |
+| dayRateLow | BigDecimal | Lowest per-day rate the Candidate will accept. | | |
+| degreeList | String (2147483647) | List of Candidate's educational degrees. Field on the edit screen, not the field in People Template. | | |
+| description | String (2147483647) | Text field, usually used to contain the Candidate's resume. | | |
+| desiredLocations | String (2147483647) | Locations where Candidate would like to work. | | |
+| disability | String (1) | Indicates whether Candidate has a disability. Allowable values can be configured using field maps. Default values are U (Unknown), Y (Yes), and N (No). | | |
+| educationDegree | String (2147483647) | Candidate's highest level of education. | | |
+| email | String (100) | Candidate's email address. | | |
+| email2 | String (100) | Additional email address. | | |
+| email3 | String (100) | Additional email address. | | |
+| employeeType | String (30) | Candidate's employee type: for example 1099 or W2. | X | |
+| employmentPreference | String (200) | Indicates type of employment the Candidate would prefer: for example, permanent, part-time, and so forth. |
+| ethnicity | String (50) | Candidate's ethnicity. | | |
+| experience | Integer | Number of years of experience that the Candidate has. | | |
+| externalID | String (50) | Used for records migrated in from other systems; often used for the Candidate's external/backoffice Id. |
+| fax | String (20) | Candidate's fax number. | | |
+| fax2 | String (20) | Additional fax number. | | |
+| fax3 | String (20) | Additional fax number. | | |
+| federalAdditionalWitholdingsAmount | BigDecimal | Number of federal withholdings the Candidate has selected on his or her W-2 tax form. | | |
+| federalExemptions | Integer | Number of federal exemptions the Candidate has indicated on his or her W-2 tax form. | | |
+| federalExtraWithholdingAmount | BigDecimal | Enter any additional tax you want withheld each pay period. | | |
+| federalFilingStatus | String (1) | Candidate's federal tax filing status. | | |
+| firstName | String (50) | Candidate's first name. | X | |
+| gender | String (1) | Candidate's gender. Options are U (unknown), M (male), F (female) | | |
+| hourlyRate | BigDecimal | Candidate's desired hourly pay rate. | | |
+| hourlyRateLow | BigDecimal | Lowest hourly pay rate the Candidate will accept. | | |
+| i9OnFile | Integer | Indicates whether Candidate's I-9 form has already been filled out and is on file. | | |
+| interviews | To-many association | Interviews for Candidate. This field is populated when you create Appointments where Appointment.candidate is this Candidate and Appointment.type is “Interview”. | X | |
+| isAnonymized | Boolean | Indicates whether this record is marked as anonymized in the Bullhorn system. | | |
+| isDeleted | Boolean | Indicates whether this record is marked as deleted in the Bullhorn system. | X | |
+| isEditable | Boolean | Indicates whether Candidate can edit his or her profile information; applicable to Candidate/Client login. | X |
+| isExempt | Boolean | To claim exemption from withholding, set this to Yes. | | |
+| lastName | String (50) | Candidate's last name. | X | |
+| leads | To-many association | Leads associated with this Candidate. | | |
+| linkedPerson | To-one association | If person represented by Candidate is also a ClientContact, this field includes the following ClientContact fields<br>: id, _subtype | | |
+| localAddtionalWitholdingsAmount | BigDecimal | Number of local withholdings the Candidate has selected on his or her W-2 tax form. | | |
+| localExemptions | Integer | Number of local exemptions Candidate has indicated on his or her W-2 tax form. | | |
+| localFilingStatus | String (1) | Candidate's local tax filing status. | | |
+| localTaxCode | String (40) | Candidate's local tax code (if local taxes apply); not required. | | |
+| maritalStatus | String | Indicates the current marital status of the candidate. | | |
+| massMailOptOut | Boolean | Indicates whether Candidate has chosen not to be included in mass emails through the Bullhorn system. | | |
+| middleName | String (50) | Candidate's middle name. | | |
+| mobile | String (20) | Candidate's mobile (cell) telephone number. | | |
+| name | String | Candidate's full name. If setting firstname or lastname, you must also set this field; it does not populate automatically. | X | |
+| namePrefix | String (5) | Candidate's name prefix, for example Dr., Ms., Mr., and so forth. | | |
+| nameSuffix | String (5) | Candidate's name suffix, for example Jr. | | |
+| nickName | String (50) | Candidate's nickname. | | |
+| numCategories | Integer | Number of Category objects associated with Candidate. | | |
+| numOwners | Integer | Number of CorporateUsers that are listed as owner of Candidate. | | |
+| occupation | String (100) | Candidate's current occupation or job title. | | |
+| onboardingDocumentReceivedCount | Integer |  Number of eStaff onboarding documents that have been received by the Candidate. | | |
+| onboardingDocumentSentCount | Integer | Number of eStaff onboarding documents that have been sent and completed by the Candidate. | | |
+| onboardingPercentComplete | Integer | Percentage of eStaff onboarding documents that a Candidate has completed. | | |
 | onboardingReceivedSent | OnboardingReceivedSent | Readonly composite field that contains:<ul><li>onboardingDocumentReceivedCount</li><li>onboardingDocumentSentCount</li></ul></ul> Use this to only view these fields.<br>To update, update the fields directly. | | |
-| onboardingStatus | String                 | Candidate's eStaff onboarding status. | | |
-| otherDeductionsAmount | BigDecimal             |  If there are other deductions to be claimed (other than standard). | | |
-| otherIncomeAmount | BigDecimal             | If you want tax withheld for other income that is expected. | | |
-| owner | To-one association     | CorporateUser who is the primary owner of Candidate. The default value is user who creates the Candidate. | X | |
-| pager | String (20)            | Candidate's pager number. | | |
-| paperWorkOnFile | String                 | Configurable field that tracks whether the Candidate's tax paperwork has been received. | | |
-| password | String                 | Candidate’s password. The default value is a randomly generated string. | X | |
-| payrollClientStartDate  | Timestamp              | Indicates Date on which the employee was first on payroll at the staffing company. Used for payroll integrations. | | |
-| payrollStatus | String                 | Indicates whether the Candidate is currently active on payroll or not. Used for payroll integrations. | | |
-| phone | String (20)            | Candidate's home telephone number. | | |
-| phone2 | String (20)            | Candidate's telephone number at work. | | |
-| phone3 | String (20)            | Alternate telephone number. | | |
-| placements | To-many association    | Placements for Candidate. This field is populated when you create Placements where Placement.candidate is this Candidate. | X | |
-| preferredContact | String (15)            | Candidate's preferred method of contact (for example, phone, email, and so forth.) | X | |
-| primarySkills | To-many association    | Skills that are listed as primary Skills for Candidate. | | |
-| recentClientList | String (2147483647)    | List of ClientCorporations for which Candidate has worked. | | |
-| referredBy | String (50)            | Name of person who referred Candidate. | | |
-| referredByPerson | To-one association     | Person who referred Candidate, if applicable. | | |
-| salary | BigDecimal             | Candidate's desired yearly salary. | | |
-| salaryLow | BigDecimal             | Lowest yearly salary the Candidate will accept. | | |
-| secondaryAddress | Address                | Candidate's work address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/Candidate?fields=address(countryID) | | |
-| secondaryOwners | To-many association    | CorporateUsers who are additional owners of Candidate. | | |
-| secondarySkills | Skill                  | Skills that are listed as secondary skills for Candidate. | | |
-| sendouts | To-many association    | Sendouts for Candidate. This field is populated when you create Sendouts where the Sendout.candidate is this Candidate. | | |
-| skillSet | String (2147483647)    | Text description of Candidate's skills. | | |
-| smsOptIn | Boolean                | Indicates whether Candidate has granted permission to be sent messages via SMS. Can only set on create calls; updates are not allowed. | | |
-| source | String (200)           | Candidate source: for example, Advertisement, Client Referral, LinkedIn, Monster.com, and so forth. Allowable values can be configured using field maps. | | |
-| specialties | To-many association    | Candidate’s specialty skills. This field is populated when you associate a Specialty with this Candidate in a to-many association operation. | | |
-| ssn | String (18)            | Candidate's Social Security Number. Check field map for proper format. | | |
-| stateAddtionalWitholdingsAmount | BigDecimal             | Number of state withholdings Candidate has selected on his or her W-2 tax form. | | |
-| stateExemptions | Integer                | Number of state exemptions Candidate has indicated on W-2 tax form. | | |
-| stateFilingStatus | String (1)             | Candidate's state tax filing status. | | |
-| status | String (100)           | Candidate status with company: for example, New Lead, Active, Offer Pending, Placed, and so forth. Allowable values can be configured using field maps. | X | |
-| submissions | To-many association    | JobSubmissions for Candidate. This field is populated when you create JobSubmissions where JobSubmission.candidate is this Candidate. | X | |
-| tasks | To-many association    | Tasks associated with Candidate. This field is populated when you create Tasks where Task.candidate is this Candidate. | | |
-| taxID | String (18)            | Id that Candidate uses for tax purposes if not SSN. | | |
-| taxState | String (30)            | State in which Candidate pays taxes. | | |
-| timeZoneOffsetEST | Integer                | Indicates the number of hours by which the Candidate's time zone differs from Eastern Standard Time. For example, Pacific Standard Time is -3, three hours earlier than Eastern. | | |
-| tobaccoUser | String                 | Indicates the tobacco usage of the candidate. | | |
-| totalDependentClaimAmount | BigDecimal             |  Total amount that are being claimed for dependents. | | |
-| travelLimit | Integer                | Maximum distance Candidate is willing to travel. | | |
-| travelMethod | String (100)           | Method of travel to job. | | |
-| twoJobs | Boolean                | If more then one job is held at a time OR if the person is married and filing jointly and their spouse also works. | | |
-| type | String (100)           | Candidate type: for example, Active, Passive, and so forth. | | |
-| userDateAdded | Timestamp              | Date the record was added to the system. | X | |
-| username | String (100)           | Candidate’s username for logging in to Bullhorn. The default value is _[random number] | X | |
-| veteran | String (1)             | Indicates whether Candidate is a veteran: Y for yes, N for no, or U for unknown. | | |
-| webResponses | To-many association    | Web responses for Candidate. This field is populated when you create JobSubmissions where JobSubmission.candidate is this Candidate and JobSubmission.status is “New Lead”. | | |
-| whitelistClientCorporations | To-many association    | Set of ClientCorporations whitelisted for this Candidate. | | |
-| willRelocate | Boolean                | Indicates whether Candidate is willing to relocate for a position. | | |
-| workAuthorized | Boolean                | Indicates whether Candidate is authorized to work in the U.S. | | |
-| workPhone | String (20)            | Candidate's telephone number at work. | | | |
+| onboardingStatus | String | Candidate's eStaff onboarding status. | | |
+| otherDeductionsAmount | BigDecimal |  If there are other deductions to be claimed (other than standard). | | |
+| otherIncomeAmount | BigDecimal | If you want tax withheld for other income that is expected. | | |
+| owner | To-one association | CorporateUser who is the primary owner of Candidate. The default value is user who creates the Candidate. | X | |
+| pager | String (20) | Candidate's pager number. | | |
+| paperWorkOnFile | String | Configurable field that tracks whether the Candidate's tax paperwork has been received. | | |
+| password | String | Candidate’s password. The default value is a randomly generated string. | X | |
+| payrollClientStartDate  | Timestamp | Indicates Date on which the employee was first on payroll at the staffing company. Used for payroll integrations. | | |
+| payrollStatus | String | Indicates whether the Candidate is currently active on payroll or not. Used for payroll integrations. | | |
+| phone | String (20) | Candidate's home telephone number. | | |
+| phone2 | String (20) | Candidate's telephone number at work. | | |
+| phone3 | String (20) | Alternate telephone number. | | |
+| placements | To-many association | Placements for Candidate. This field is populated when you create Placements where Placement.candidate is this Candidate. | X | |
+| preferredContact | String (15) | Candidate's preferred method of contact (for example, phone, email, and so forth.) | X | |
+| primarySkills | To-many association | Skills that are listed as primary Skills for Candidate. | | |
+| recentClientList | String (2147483647) | List of ClientCorporations for which Candidate has worked. | | |
+| referredBy | String (50) | Name of person who referred Candidate. | | |
+| referredByPerson | To-one association | Person who referred Candidate, if applicable. | | |
+| salary | BigDecimal | Candidate's desired yearly salary. | | |
+| salaryLow | BigDecimal | Lowest yearly salary the Candidate will accept. | | |
+| secondaryAddress | Address | Candidate's work address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/Candidate?fields=address(countryID) | | |
+| secondaryOwners | To-many association | CorporateUsers who are additional owners of Candidate. | | |
+| secondarySkills | Skill | Skills that are listed as secondary skills for Candidate. | | |
+| sendouts | To-many association | Sendouts for Candidate. This field is populated when you create Sendouts where the Sendout.candidate is this Candidate. | | |
+| skillSet | String (2147483647) | Text description of Candidate's skills. | | |
+| smsOptIn | Boolean | Indicates whether Candidate has granted permission to be sent messages via SMS. Can only set on create calls; updates are not allowed. | | |
+| source | String (200) | Candidate source: for example, Advertisement, Client Referral, LinkedIn, Monster.com, and so forth. Allowable values can be configured using field maps. | | |
+| specialties | To-many association | Candidate’s specialty skills. This field is populated when you associate a Specialty with this Candidate in a to-many association operation. | | |
+| ssn | String (18) | Candidate's Social Security Number. Check field map for proper format. | | |
+| stateAddtionalWitholdingsAmount | BigDecimal | Number of state withholdings Candidate has selected on his or her W-2 tax form. | | |
+| stateExemptions | Integer | Number of state exemptions Candidate has indicated on W-2 tax form. | | |
+| stateFilingStatus | String (1) | Candidate's state tax filing status. | | |
+| status | String (100) | Candidate status with company: for example, New Lead, Active, Offer Pending, Placed, and so forth. Allowable values can be configured using field maps. | X | |
+| submissions | To-many association | JobSubmissions for Candidate. This field is populated when you create JobSubmissions where JobSubmission.candidate is this Candidate. | X | |
+| tasks | To-many association | Tasks associated with Candidate. This field is populated when you create Tasks where Task.candidate is this Candidate. | | |
+| taxID | String (18) | Id that Candidate uses for tax purposes if not SSN. | | |
+| taxState | String (30) | State in which Candidate pays taxes. | | |
+| timeZoneOffsetEST | Integer | Indicates the number of hours by which the Candidate's time zone differs from Eastern Standard Time. For example, Pacific Standard Time is -3, three hours earlier than Eastern. | | |
+| tobaccoUser | String | Indicates the tobacco usage of the candidate. | | |
+| totalDependentClaimAmount | BigDecimal |  Total amount that are being claimed for dependents. | | |
+| travelLimit | Integer | Maximum distance Candidate is willing to travel. | | |
+| travelMethod | String (100) | Method of travel to job. | | |
+| twoJobs | Boolean | If more then one job is held at a time OR if the person is married and filing jointly and their spouse also works. | | |
+| type | String (100) | Candidate type: for example, Active, Passive, and so forth. | | |
+| userDateAdded | Timestamp | Date the record was added to the system. | X | |
+| username | String (100) | Candidate’s username for logging in to Bullhorn. The default value is _[random number] | X | |
+| veteran | String (1) | Indicates whether Candidate is a veteran: Y for yes, N for no, or U for unknown. | | |
+| webResponses | To-many association | Web responses for Candidate. This field is populated when you create JobSubmissions where JobSubmission.candidate is this Candidate and JobSubmission.status is “New Lead”. | | |
+| whitelistClientCorporations | To-many association | Set of ClientCorporations whitelisted for this Candidate. | | |
+| willRelocate | Boolean | Indicates whether Candidate is willing to relocate for a position. | | |
+| workAuthorized | Boolean | Indicates whether Candidate is authorized to work in the U.S. | | |
+| workPhone | String (20) | Candidate's telephone number at work. | | | |
 
 ## Candidate confidential fields
 

--- a/source/includes/entityref/_clientcontact.md
+++ b/source/includes/entityref/_clientcontact.md
@@ -4,69 +4,69 @@ Represents a contact person who works at a ClientCorporation. A ClientContact ca
 
 The ClientContact entity supports the massUpdate operations.
 
-| **ClientContact field** | **Type** | **Description** | **Not null** | **Read-only** |
-| --- | --- | --- | --- | --- |
-| id | Integer | Unique identifier for this entity. | X | X |
-| address | Address | Contact's  address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/ClientContact?fields=address(countryID) | | |
-| businessSectors | To-many association | Ids of BusinessSectors in which the Contact operates. | | |
-| category | To-one association | Contact's primary Category. The default value is the Other Area(s) category for the user’s private label or the first Category. | X | |
-| categories | To-many association | Ids of the Categories associated with the Contact. Note that the categoryId property is used to store the contact's primary Category, while this association hold that Category and any other Categories to which the Contact belongs. | | |
-| certifications | String (2147483647) | Contact's certifications. | | |
-| clientCorporation | To-one association | ClientCorporation for which the Contact works. | X | |
-| comments | String (2147483647) | Free-text comments on this Contact. | | |
-| customDate1-3 | Timestamp | Configurable date fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customFloat1-3 | Double | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customInt1-3 | Integer | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-customObject1s to 35s | CustomObject | Fields to which custom objects can be assigned. For more information about custom objects, see the Bullhorn Resource Center and the following article on using the REST API with custom objects:<br>[http://bullhorn.github.io/Custom-Objects](http://bullhorn.github.io/Custom-Objects) | | |
-| customText1-20 | String (100) | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customTextBlock1-5 | String (2147483647) | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| dateAdded | Timestamp | Date on which this record was created in the Bullhorn system. | X | |
-| dateLastModified | Timestamp | Date on which the ClientContact was last modified. | X | X |
-| dateLastVisit | Timestamp | Date of ClientContact’s last visit. | | |
-| description | String  (2147483647) | Large text field for additional information about the contact. | | |
-| desiredCategories | String (255) | Categories that the ClientContact wants Candidates to belong to. | | |
-| desiredSkills | String (255) | Skills that the ClientContact wants his or her Candidates to have. | | |
-| desiredSpecialties | String (255) | Specialties that the ClientContact wants his or her Candidates to have. | | |
-| division | String (40) | Department that the Contact is associated with. | | |
-| email | String (60) | ClientContact's primary (work) email address. | X | |
-| email2 | String (100) | Additional email address. Typically used for the ClientContact’s home or personal email. | | |
-| email3 | String (100) | Additional email address. | | |
-| externalID | String (30) | External identifier for the record, used for migrations and back-office Integration. | | |
-| fax | String (20) | ClientContact's primary (work) fax number. | | |
-| fax2 | String (20) | Additional fax number. Typically used for the contact's home or personal fax. | | |
-| fax3 | String (20) | Additional fax number. | | |
-| firstName | String (50) | ClientContact's first name. | | |
-| isAnonymized | Boolean | Indicates whether this record is marked as anonymized in the Bullhorn system. | | |
-| isDayLightSavings | Boolean | Indicates whether the ClientContact's location is using Daylight Saving Time. | | |
-| isDeleted | Boolean | Indicates whether this record has been marked as deleted in the Bullhorn system. | X | |
-| lastName | String (50) | ClientContact's last name. | | |
-| leads | To-many association | Leads associated with this ClientContact. | | |
+| **ClientContact field** | **Type**                                           | **Description** | **Not null** | **Read-only** |
+| --- |----------------------------------------------------| --- | --- | --- |
+| id | Integer                                            | Unique identifier for this entity. | X | X |
+| address | Address                                            | Contact's  address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/ClientContact?fields=address(countryID) | | |
+| businessSectors | To-many association                                | Ids of BusinessSectors in which the Contact operates. | | |
+| category | To-one association                                 | Contact's primary Category. The default value is the Other Area(s) category for the user’s private label or the first Category. | X | |
+| categories | To-many association                                | Ids of the Categories associated with the Contact. Note that the categoryId property is used to store the contact's primary Category, while this association hold that Category and any other Categories to which the Contact belongs. | | |
+| certifications | String (2147483647)                                | Contact's certifications. | | |
+| clientCorporation | To-one association                                 | ClientCorporation for which the Contact works. | X | |
+| comments | String (2147483647)                                | Free-text comments on this Contact. | | |
+| customDate1-3 | Timestamp                                          | Configurable date fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customFloat1-3 | Double                                             | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customInt1-3 | Integer                                            | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+customObject1s to 35s | CustomObject                                       | Fields to which custom objects can be assigned. For more information about custom objects, see the Bullhorn Resource Center and the following article on using the REST API with custom objects:<br>[http://bullhorn.github.io/Custom-Objects](http://bullhorn.github.io/Custom-Objects) | | |
+| customText1-20 | String (100)                                       | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customTextBlock1-5 | String (2147483647)                                | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| dateAdded | Timestamp                                          | Date on which this record was created in the Bullhorn system. | X | |
+| dateLastModified | Timestamp                                          | Date on which the ClientContact was last modified. | X | X |
+| dateLastVisit | Timestamp                                          | Date of ClientContact’s last visit. | | |
+| description | String  (2147483647)                               | Large text field for additional information about the contact. | | |
+| desiredCategories | String (255)                                       | Categories that the ClientContact wants Candidates to belong to. | | |
+| desiredSkills | String (255)                                       | Skills that the ClientContact wants his or her Candidates to have. | | |
+| desiredSpecialties | String (255)                                       | Specialties that the ClientContact wants his or her Candidates to have. | | |
+| division | String (40)                                        | Department that the Contact is associated with. | | |
+| email | String (60)                                        | ClientContact's primary (work) email address. | X | |
+| email2 | String (100)                                       | Additional email address. Typically used for the ClientContact’s home or personal email. | | |
+| email3 | String (100)                                       | Additional email address. | | |
+| externalID | String (30)                                        | External identifier for the record, used for migrations and back-office Integration. | | |
+| fax | String (20)                                        | ClientContact's primary (work) fax number. | | |
+| fax2 | String (20)                                        | Additional fax number. Typically used for the contact's home or personal fax. | | |
+| fax3 | String (20)                                        | Additional fax number. | | |
+| firstName | String (50)                                        | ClientContact's first name. | | |
+| isAnonymized | Boolean                                            | Indicates whether this record is marked as anonymized in the Bullhorn system. | | |
+| isDayLightSavings | Boolean                                            | Indicates whether the ClientContact's location is using Daylight Saving Time. | | |
+| isDeleted | Boolean                                            | Indicates whether this record has been marked as deleted in the Bullhorn system. | X | |
+| lastName | String (50)                                        | ClientContact's last name. | | |
+| leads | To-many association                                | Leads associated with this ClientContact. | | |
 | linkedPerson | Person (superclass of Candidate and ClientContact) | If the person represented by this ClientContact is also a Candidate, this field includes the following Candidate fields: id, _subtype | | |
-| massMailOptOut | Boolean | Indicates whether the Contact has chosen not to be included in mass emails through the Bullhorn system. | X | |
-| middleName | String (50) | ClientContact's middle name. | | |
-| mobile | String (20) | ClientContact's mobile (cellular) telephone number. | | |
-| name | String (100) | ClientContact's full name. Should be a combination of the firstName and lastName fields separated by a space. **Notes:** If you create a ClientContact with no value in the name field, users will have no way to select that ClientContact in the Bullhorn staffing application. If you create or modify a ClientContact name that is not a combination of the firstName and lastName fields, the name will be overwritten when a user saves the ClientContact in the Bullhorn staffing application. The name will change to a combination of the firstName and lastName fields. | | |
-| namePrefix | String (5) | ClientContact's name prefix, for example Dr., Ms, Mr., and so forth. | | |
-| nameSuffix | String (5) | ClientContact's name suffix, for example Jr. | | |
-| nickName | String | ClientContact's nickname. | | |
-| numEmployees | Integer | Number of employees who report to this Contact. | X | |
-| occupation | String (50) | ClientContact's job title. | | |
-| office | String (40) | For companies with multiple locations, this field can be used to indicate which office this contact works out of. | | |
-| owner | To-one association | CorporateUser who is the owner of this Contact record. The default value is user who creates the ClientContact. | X | |
-| pager | String (20) | ClientContact's pager number. | | |
-| password | String | ClientContact's password for logging in to Bullhorn. The default value is a randomly generated string. | X | |
-| phone | String (20) | ClientContact's primary (work) telephone number. | | |
-| phone2 | String (20) | Alternate phone number. Typically used for the contact's home phone number. | | |
-| phone3 | String (20) | Alternate phone number. | | |
-| preferredContact | String (15) | Contact's preferred method of contact (For example, phone, email, and so forth.) | X | |
-| referredByPerson | Person | Person who referred this ClientContact. | | |
-| reportToPerson | Person | Person to whom this ClientContact reports. | | |
-| secondaryAddress | Address | ClientContact's secondary (home)  address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/ClientContact?fields=address(countryID). | | |
-| secondaryOwners | To-many association | Ids of internal users who are secondary owners of this Contact. Note that the owner property is used to store the ClientContact’s primary owner, while this association hold that person and any other owners of the Contact. | | |
-| skills | To-many association | Ids of Skills that the ClientContact wants Candidates to have. | | |
-| smsOptIn | Boolean | Indicates whether the ClientContact has granted permission to be sent messages via SMS.  Can only set on create calls; updates are not allowed. | | |
-| source | String (200) | Source from which this ClientContact was found. | | |
-| status | String (30) | Status of the contact; for example, New Lead, Active, Prospect, and so forth. Possible values can be configured using field maps. | X | |
-| timeZoneOffsetEST | Integer | Indicates the number of hours by which the ClientContact's time zone differs from Eastern Standard Time. For example, Pacific Standard Time is -3, three hours earlier than Eastern. | | |
-| type | String (30) | Describes the type of ClientContact (for example, Primary, Secondary, Target, Gatekeeper). Possible values can be configured using field maps. | X | |
-| username | String (100) | ClientContact's username for logging in to Bullhorn. The default value is _[random number] | X | |
+| massMailOptOut | Boolean                                            | Indicates whether the Contact has chosen not to be included in mass emails through the Bullhorn system. | X | |
+| middleName | String (50)                                        | ClientContact's middle name. | | |
+| mobile | String (20)                                        | ClientContact's mobile (cellular) telephone number. | | |
+| name | String (100)                                       | ClientContact's full name. Should be a combination of the firstName and lastName fields separated by a space. **Notes:** If you create a ClientContact with no value in the name field, users will have no way to select that ClientContact in the Bullhorn staffing application. If you create or modify a ClientContact name that is not a combination of the firstName and lastName fields, the name will be overwritten when a user saves the ClientContact in the Bullhorn staffing application. The name will change to a combination of the firstName and lastName fields. | | |
+| namePrefix | String (5)                                         | ClientContact's name prefix, for example Dr., Ms, Mr., and so forth. | | |
+| nameSuffix | String (5)                                         | ClientContact's name suffix, for example Jr. | | |
+| nickName | String                                             | ClientContact's nickname. | | |
+| numEmployees | Integer                                            | Number of employees who report to this Contact. | X | |
+| occupation | String (100)                                       | ClientContact's job title. | | |
+| office | String (40)                                        | For companies with multiple locations, this field can be used to indicate which office this contact works out of. | | |
+| owner | To-one association                                 | CorporateUser who is the owner of this Contact record. The default value is user who creates the ClientContact. | X | |
+| pager | String (20)                                        | ClientContact's pager number. | | |
+| password | String                                             | ClientContact's password for logging in to Bullhorn. The default value is a randomly generated string. | X | |
+| phone | String (20)                                        | ClientContact's primary (work) telephone number. | | |
+| phone2 | String (20)                                        | Alternate phone number. Typically used for the contact's home phone number. | | |
+| phone3 | String (20)                                        | Alternate phone number. | | |
+| preferredContact | String (15)                                        | Contact's preferred method of contact (For example, phone, email, and so forth.) | X | |
+| referredByPerson | Person                                             | Person who referred this ClientContact. | | |
+| reportToPerson | Person                                             | Person to whom this ClientContact reports. | | |
+| secondaryAddress | Address                                            | ClientContact's secondary (home)  address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/ClientContact?fields=address(countryID). | | |
+| secondaryOwners | To-many association                                | Ids of internal users who are secondary owners of this Contact. Note that the owner property is used to store the ClientContact’s primary owner, while this association hold that person and any other owners of the Contact. | | |
+| skills | To-many association                                | Ids of Skills that the ClientContact wants Candidates to have. | | |
+| smsOptIn | Boolean                                            | Indicates whether the ClientContact has granted permission to be sent messages via SMS.  Can only set on create calls; updates are not allowed. | | |
+| source | String (200)                                       | Source from which this ClientContact was found. | | |
+| status | String (30)                                        | Status of the contact; for example, New Lead, Active, Prospect, and so forth. Possible values can be configured using field maps. | X | |
+| timeZoneOffsetEST | Integer                                            | Indicates the number of hours by which the ClientContact's time zone differs from Eastern Standard Time. For example, Pacific Standard Time is -3, three hours earlier than Eastern. | | |
+| type | String (30)                                        | Describes the type of ClientContact (for example, Primary, Secondary, Target, Gatekeeper). Possible values can be configured using field maps. | X | |
+| username | String (100)                                       | ClientContact's username for logging in to Bullhorn. The default value is _[random number] | X | |

--- a/source/includes/entityref/_clientcontact.md
+++ b/source/includes/entityref/_clientcontact.md
@@ -4,69 +4,69 @@ Represents a contact person who works at a ClientCorporation. A ClientContact ca
 
 The ClientContact entity supports the massUpdate operations.
 
-| **ClientContact field** | **Type**                                           | **Description** | **Not null** | **Read-only** |
-| --- |----------------------------------------------------| --- | --- | --- |
-| id | Integer                                            | Unique identifier for this entity. | X | X |
-| address | Address                                            | Contact's  address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/ClientContact?fields=address(countryID) | | |
-| businessSectors | To-many association                                | Ids of BusinessSectors in which the Contact operates. | | |
-| category | To-one association                                 | Contact's primary Category. The default value is the Other Area(s) category for the user’s private label or the first Category. | X | |
-| categories | To-many association                                | Ids of the Categories associated with the Contact. Note that the categoryId property is used to store the contact's primary Category, while this association hold that Category and any other Categories to which the Contact belongs. | | |
-| certifications | String (2147483647)                                | Contact's certifications. | | |
-| clientCorporation | To-one association                                 | ClientCorporation for which the Contact works. | X | |
-| comments | String (2147483647)                                | Free-text comments on this Contact. | | |
-| customDate1-3 | Timestamp                                          | Configurable date fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customFloat1-3 | Double                                             | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customInt1-3 | Integer                                            | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-customObject1s to 35s | CustomObject                                       | Fields to which custom objects can be assigned. For more information about custom objects, see the Bullhorn Resource Center and the following article on using the REST API with custom objects:<br>[http://bullhorn.github.io/Custom-Objects](http://bullhorn.github.io/Custom-Objects) | | |
-| customText1-20 | String (100)                                       | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| customTextBlock1-5 | String (2147483647)                                | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
-| dateAdded | Timestamp                                          | Date on which this record was created in the Bullhorn system. | X | |
-| dateLastModified | Timestamp                                          | Date on which the ClientContact was last modified. | X | X |
-| dateLastVisit | Timestamp                                          | Date of ClientContact’s last visit. | | |
-| description | String  (2147483647)                               | Large text field for additional information about the contact. | | |
-| desiredCategories | String (255)                                       | Categories that the ClientContact wants Candidates to belong to. | | |
-| desiredSkills | String (255)                                       | Skills that the ClientContact wants his or her Candidates to have. | | |
-| desiredSpecialties | String (255)                                       | Specialties that the ClientContact wants his or her Candidates to have. | | |
-| division | String (40)                                        | Department that the Contact is associated with. | | |
-| email | String (60)                                        | ClientContact's primary (work) email address. | X | |
-| email2 | String (100)                                       | Additional email address. Typically used for the ClientContact’s home or personal email. | | |
-| email3 | String (100)                                       | Additional email address. | | |
-| externalID | String (30)                                        | External identifier for the record, used for migrations and back-office Integration. | | |
-| fax | String (20)                                        | ClientContact's primary (work) fax number. | | |
-| fax2 | String (20)                                        | Additional fax number. Typically used for the contact's home or personal fax. | | |
-| fax3 | String (20)                                        | Additional fax number. | | |
-| firstName | String (50)                                        | ClientContact's first name. | | |
-| isAnonymized | Boolean                                            | Indicates whether this record is marked as anonymized in the Bullhorn system. | | |
-| isDayLightSavings | Boolean                                            | Indicates whether the ClientContact's location is using Daylight Saving Time. | | |
-| isDeleted | Boolean                                            | Indicates whether this record has been marked as deleted in the Bullhorn system. | X | |
-| lastName | String (50)                                        | ClientContact's last name. | | |
-| leads | To-many association                                | Leads associated with this ClientContact. | | |
+| **ClientContact field** | **Type** | **Description** | **Not null** | **Read-only** |
+| --- | --- | --- | --- | --- |
+| id | Integer | Unique identifier for this entity. | X | X |
+| address | Address | Contact's  address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/ClientContact?fields=address(countryID) | | |
+| businessSectors | To-many association | Ids of BusinessSectors in which the Contact operates. | | |
+| category | To-one association | Contact's primary Category. The default value is the Other Area(s) category for the user’s private label or the first Category. | X | |
+| categories | To-many association | Ids of the Categories associated with the Contact. Note that the categoryId property is used to store the contact's primary Category, while this association hold that Category and any other Categories to which the Contact belongs. | | |
+| certifications | String (2147483647) | Contact's certifications. | | |
+| clientCorporation | To-one association | ClientCorporation for which the Contact works. | X | |
+| comments | String (2147483647) | Free-text comments on this Contact. | | |
+| customDate1-3 | Timestamp | Configurable date fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customFloat1-3 | Double | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customInt1-3 | Integer | Configurable numeric fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+customObject1s to 35s | CustomObject | Fields to which custom objects can be assigned. For more information about custom objects, see the Bullhorn Resource Center and the following article on using the REST API with custom objects:<br>[http://bullhorn.github.io/Custom-Objects](http://bullhorn.github.io/Custom-Objects) | | |
+| customText1-20 | String (100) | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| customTextBlock1-5 | String (2147483647) | Configurable text fields that can be used to store custom data depending on the needs of a particular deployment. | | |
+| dateAdded | Timestamp | Date on which this record was created in the Bullhorn system. | X | |
+| dateLastModified | Timestamp | Date on which the ClientContact was last modified. | X | X |
+| dateLastVisit | Timestamp | Date of ClientContact’s last visit. | | |
+| description | String  (2147483647) | Large text field for additional information about the contact. | | |
+| desiredCategories | String (255) | Categories that the ClientContact wants Candidates to belong to. | | |
+| desiredSkills | String (255) | Skills that the ClientContact wants his or her Candidates to have. | | |
+| desiredSpecialties | String (255) | Specialties that the ClientContact wants his or her Candidates to have. | | |
+| division | String (40) | Department that the Contact is associated with. | | |
+| email | String (60) | ClientContact's primary (work) email address. | X | |
+| email2 | String (100) | Additional email address. Typically used for the ClientContact’s home or personal email. | | |
+| email3 | String (100) | Additional email address. | | |
+| externalID | String (30) | External identifier for the record, used for migrations and back-office Integration. | | |
+| fax | String (20) | ClientContact's primary (work) fax number. | | |
+| fax2 | String (20) | Additional fax number. Typically used for the contact's home or personal fax. | | |
+| fax3 | String (20) | Additional fax number. | | |
+| firstName | String (50) | ClientContact's first name. | | |
+| isAnonymized | Boolean | Indicates whether this record is marked as anonymized in the Bullhorn system. | | |
+| isDayLightSavings | Boolean | Indicates whether the ClientContact's location is using Daylight Saving Time. | | |
+| isDeleted | Boolean | Indicates whether this record has been marked as deleted in the Bullhorn system. | X | |
+| lastName | String (50) | ClientContact's last name. | | |
+| leads | To-many association | Leads associated with this ClientContact. | | |
 | linkedPerson | Person (superclass of Candidate and ClientContact) | If the person represented by this ClientContact is also a Candidate, this field includes the following Candidate fields: id, _subtype | | |
-| massMailOptOut | Boolean                                            | Indicates whether the Contact has chosen not to be included in mass emails through the Bullhorn system. | X | |
-| middleName | String (50)                                        | ClientContact's middle name. | | |
-| mobile | String (20)                                        | ClientContact's mobile (cellular) telephone number. | | |
-| name | String (100)                                       | ClientContact's full name. Should be a combination of the firstName and lastName fields separated by a space. **Notes:** If you create a ClientContact with no value in the name field, users will have no way to select that ClientContact in the Bullhorn staffing application. If you create or modify a ClientContact name that is not a combination of the firstName and lastName fields, the name will be overwritten when a user saves the ClientContact in the Bullhorn staffing application. The name will change to a combination of the firstName and lastName fields. | | |
-| namePrefix | String (5)                                         | ClientContact's name prefix, for example Dr., Ms, Mr., and so forth. | | |
-| nameSuffix | String (5)                                         | ClientContact's name suffix, for example Jr. | | |
-| nickName | String                                             | ClientContact's nickname. | | |
-| numEmployees | Integer                                            | Number of employees who report to this Contact. | X | |
-| occupation | String (100)                                       | ClientContact's job title. | | |
-| office | String (40)                                        | For companies with multiple locations, this field can be used to indicate which office this contact works out of. | | |
-| owner | To-one association                                 | CorporateUser who is the owner of this Contact record. The default value is user who creates the ClientContact. | X | |
-| pager | String (20)                                        | ClientContact's pager number. | | |
-| password | String                                             | ClientContact's password for logging in to Bullhorn. The default value is a randomly generated string. | X | |
-| phone | String (20)                                        | ClientContact's primary (work) telephone number. | | |
-| phone2 | String (20)                                        | Alternate phone number. Typically used for the contact's home phone number. | | |
-| phone3 | String (20)                                        | Alternate phone number. | | |
-| preferredContact | String (15)                                        | Contact's preferred method of contact (For example, phone, email, and so forth.) | X | |
-| referredByPerson | Person                                             | Person who referred this ClientContact. | | |
-| reportToPerson | Person                                             | Person to whom this ClientContact reports. | | |
-| secondaryAddress | Address                                            | ClientContact's secondary (home)  address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/ClientContact?fields=address(countryID). | | |
-| secondaryOwners | To-many association                                | Ids of internal users who are secondary owners of this Contact. Note that the owner property is used to store the ClientContact’s primary owner, while this association hold that person and any other owners of the Contact. | | |
-| skills | To-many association                                | Ids of Skills that the ClientContact wants Candidates to have. | | |
-| smsOptIn | Boolean                                            | Indicates whether the ClientContact has granted permission to be sent messages via SMS.  Can only set on create calls; updates are not allowed. | | |
-| source | String (200)                                       | Source from which this ClientContact was found. | | |
-| status | String (30)                                        | Status of the contact; for example, New Lead, Active, Prospect, and so forth. Possible values can be configured using field maps. | X | |
-| timeZoneOffsetEST | Integer                                            | Indicates the number of hours by which the ClientContact's time zone differs from Eastern Standard Time. For example, Pacific Standard Time is -3, three hours earlier than Eastern. | | |
-| type | String (30)                                        | Describes the type of ClientContact (for example, Primary, Secondary, Target, Gatekeeper). Possible values can be configured using field maps. | X | |
-| username | String (100)                                       | ClientContact's username for logging in to Bullhorn. The default value is _[random number] | X | |
+| massMailOptOut | Boolean | Indicates whether the Contact has chosen not to be included in mass emails through the Bullhorn system. | X | |
+| middleName | String (50) | ClientContact's middle name. | | |
+| mobile | String (20) | ClientContact's mobile (cellular) telephone number. | | |
+| name | String (100) | ClientContact's full name. Should be a combination of the firstName and lastName fields separated by a space. **Notes:** If you create a ClientContact with no value in the name field, users will have no way to select that ClientContact in the Bullhorn staffing application. If you create or modify a ClientContact name that is not a combination of the firstName and lastName fields, the name will be overwritten when a user saves the ClientContact in the Bullhorn staffing application. The name will change to a combination of the firstName and lastName fields. | | |
+| namePrefix | String (5) | ClientContact's name prefix, for example Dr., Ms, Mr., and so forth. | | |
+| nameSuffix | String (5) | ClientContact's name suffix, for example Jr. | | |
+| nickName | String | ClientContact's nickname. | | |
+| numEmployees | Integer | Number of employees who report to this Contact. | X | |
+| occupation | String (100) | ClientContact's job title. | | |
+| office | String (40) | For companies with multiple locations, this field can be used to indicate which office this contact works out of. | | |
+| owner | To-one association | CorporateUser who is the owner of this Contact record. The default value is user who creates the ClientContact. | X | |
+| pager | String (20) | ClientContact's pager number. | | |
+| password | String | ClientContact's password for logging in to Bullhorn. The default value is a randomly generated string. | X | |
+| phone | String (20) | ClientContact's primary (work) telephone number. | | |
+| phone2 | String (20) | Alternate phone number. Typically used for the contact's home phone number. | | |
+| phone3 | String (20) | Alternate phone number. | | |
+| preferredContact | String (15) | Contact's preferred method of contact (For example, phone, email, and so forth.) | X | |
+| referredByPerson | Person | Person who referred this ClientContact. | | |
+| reportToPerson | Person | Person to whom this ClientContact reports. | | |
+| secondaryAddress | Address | ClientContact's secondary (home)  address:<ul><li>address1</li><li>address2</li><li>city</li><li>state</li><li>zip</li><li>countryID: options:<ul><li>value: 1</li><li>value: 2</li></ul></ul>Use the following REST call to get the list of countryIDs and labels:<br>/meta/ClientContact?fields=address(countryID). | | |
+| secondaryOwners | To-many association | Ids of internal users who are secondary owners of this Contact. Note that the owner property is used to store the ClientContact’s primary owner, while this association hold that person and any other owners of the Contact. | | |
+| skills | To-many association | Ids of Skills that the ClientContact wants Candidates to have. | | |
+| smsOptIn | Boolean | Indicates whether the ClientContact has granted permission to be sent messages via SMS.  Can only set on create calls; updates are not allowed. | | |
+| source | String (200) | Source from which this ClientContact was found. | | |
+| status | String (30) | Status of the contact; for example, New Lead, Active, Prospect, and so forth. Possible values can be configured using field maps. | X | |
+| timeZoneOffsetEST | Integer | Indicates the number of hours by which the ClientContact's time zone differs from Eastern Standard Time. For example, Pacific Standard Time is -3, three hours earlier than Eastern. | | |
+| type | String (30) | Describes the type of ClientContact (for example, Primary, Secondary, Target, Gatekeeper). Possible values can be configured using field maps. | X | |
+| username | String (100) | ClientContact's username for logging in to Bullhorn. The default value is _[random number] | X | |


### PR DESCRIPTION
Modify the API documentation to accurately display the character limit for candidate.occupation and clientcontact.occupation fields.