### PR TITLE
BH-94438 updates job submission entity ref to include 'history' prop

### DIFF
--- a/source/includes/changelog/changelog.md
+++ b/source/includes/changelog/changelog.md
@@ -2,7 +2,7 @@
 
 This is where you can find a list of changes to the Bullhorn REST API. This change log was initiated with the 2024.5 release. Prior changes are not listed by release.
 
-## April 2025 Release (2025.4)
+## May 2025 Release (2025.5)
 
 | ADDED ```|``` [JobSubmission history field](https://bullhorn.github.io/rest-api-docs/entityref.html#jobsubmission) |
 

--- a/source/includes/changelog/changelog.md
+++ b/source/includes/changelog/changelog.md
@@ -2,6 +2,10 @@
 
 This is where you can find a list of changes to the Bullhorn REST API. This change log was initiated with the 2024.5 release. Prior changes are not listed by release.
 
+## April 2025 Release (2025.4)
+
+| ADDED ```|``` [JobSubmission history field](https://bullhorn.github.io/rest-api-docs/entityref.html#jobsubmission) |
+
 ## March 2025 Release (2025.3)
 
 | ADDED ```|``` [CustomerRequiredFieldMeta Service](http://bullhorn.github.io/rest-api-docs/index.html#post-services-customerrequiredfieldmeta) |
@@ -33,7 +37,6 @@ This is where you can find a list of changes to the Bullhorn REST API. This chan
 | UPDATED ```|``` [CustomerRequiredFieldConfigurationVersionOption entity](https://bullhorn.github.io/rest-api-docs/entityref.html#pay-and-bill-customerrequiredfieldconfigurationversionoption) |
 
 | ADDED ```|``` [Data Hub Reference Guide](https://bullhorn.github.io/rest-api-docs/datahubref.html) |
-
 
 ## February 2025 Release (2025.2)
 

--- a/source/includes/entityref/_jobsubmission.md
+++ b/source/includes/entityref/_jobsubmission.md
@@ -131,6 +131,13 @@ The JobSubmission entity supports the massUpdate operations.
             <td></td>
         </tr>
         <tr class="odd">
+            <td>history</td>
+            <td>To Many Association</td>
+            <td>JobSubmissionHistory</td>
+            <td></td>
+            <td>X</td>
+        </tr>
+        <tr class="odd">
             <td>isDeleted</td>
             <td>Boolean</td>
             <td>Indicates whether this record is marked as deleted in the Bullhorn system.</td>


### PR DESCRIPTION
Adds 'history' property information to JobSubmission entity reference